### PR TITLE
Add haptics and sound managers

### DIFF
--- a/WristBop/WristBop Watch App/FeedbackConstants.swift
+++ b/WristBop/WristBop Watch App/FeedbackConstants.swift
@@ -1,0 +1,26 @@
+import WatchKit
+
+enum GameFeedbackEvent {
+    case tick
+    case success
+    case failure
+    case speedUp
+}
+
+enum FeedbackConstants {
+    // Map gameplay events to watch haptic types
+    static let hapticMapping: [GameFeedbackEvent: WKHapticType] = [
+        .tick: .click,
+        .success: .success,
+        .failure: .failure,
+        .speedUp: .directionUp
+    ]
+
+    // Map events to optional bundled sound asset names (add files later as needed)
+    static let soundAssetNames: [GameFeedbackEvent: String] = [
+        .tick: "tick",
+        .success: "success",
+        .failure: "failure",
+        .speedUp: "speedup"
+    ]
+}

--- a/WristBop/WristBop Watch App/HapticsManager.swift
+++ b/WristBop/WristBop Watch App/HapticsManager.swift
@@ -1,0 +1,14 @@
+import WatchKit
+
+final class HapticsManager {
+    private let device: WKInterfaceDevice
+
+    init(device: WKInterfaceDevice = .current()) {
+        self.device = device
+    }
+
+    func play(_ event: GameFeedbackEvent) {
+        guard let haptic = FeedbackConstants.hapticMapping[event] else { return }
+        device.play(haptic)
+    }
+}

--- a/WristBop/WristBop Watch App/SoundManager.swift
+++ b/WristBop/WristBop Watch App/SoundManager.swift
@@ -1,0 +1,32 @@
+import AVFoundation
+
+final class SoundManager {
+    private var players: [GameFeedbackEvent: AVAudioPlayer] = [:]
+    private let bundle: Bundle
+
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+    }
+
+    func play(_ event: GameFeedbackEvent) {
+        guard let name = FeedbackConstants.soundAssetNames[event],
+              let url = bundle.url(forResource: name, withExtension: "caf") ?? bundle.url(forResource: name, withExtension: "wav") else {
+            return
+        }
+
+        if let player = players[event] {
+            player.currentTime = 0
+            player.play()
+            return
+        }
+
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.prepareToPlay()
+            players[event] = player
+            player.play()
+        } catch {
+            // If the asset can't be played, fail silently for now.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HapticsManager/SoundManager with shared feedback constants and event enum
- wire GameViewModel to play tick/success/failure/speed-up cues via the managers

## Testing
- swift test --parallel (passes; existing swift-testing deprecation warnings remain)