### PR TITLE
Replace circular timers with perimeter progress ring

### DIFF
--- a/WristBop/WristBop Watch App/CountdownView.swift
+++ b/WristBop/WristBop Watch App/CountdownView.swift
@@ -13,29 +13,10 @@ struct CountdownView: View {
 
     var body: some View {
         ZStack {
-            // Full-screen circular timer at edge
-            GeometryReader { geometry in
-                ZStack {
-                    // Background circle at edge
-                    Circle()
-                        .stroke(Color.gray.opacity(0.2), lineWidth: 6)
-                        .frame(width: geometry.size.width - 10, height: geometry.size.height - 10)
-                        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-
-                    // Animated countdown ring at edge
-                    Circle()
-                        .trim(from: 0, to: viewModel.countdownTimeRemaining / 3.0)
-                        .stroke(
-                            Color.blue,
-                            style: StrokeStyle(lineWidth: 6, lineCap: .round)
-                        )
-                        .frame(width: geometry.size.width - 10, height: geometry.size.height - 10)
-                        .rotationEffect(.degrees(-90))
-                        .animation(.linear(duration: 0.05), value: viewModel.countdownTimeRemaining)
-                        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-                }
-            }
-            .ignoresSafeArea()
+            PerimeterProgressRing(
+                progress: viewModel.countdownTimeRemaining / 3.0,
+                ringColor: .blue
+            )
 
             // Center text
             VStack {

--- a/WristBop/WristBop Watch App/GamePlayView.swift
+++ b/WristBop/WristBop Watch App/GamePlayView.swift
@@ -13,29 +13,10 @@ struct GamePlayView: View {
 
     var body: some View {
         ZStack {
-            // Full-screen circular timer at edge
-            GeometryReader { geometry in
-                ZStack {
-                    // Background circle at edge
-                    Circle()
-                        .stroke(Color.gray.opacity(0.2), lineWidth: 6)
-                        .frame(width: geometry.size.width - 10, height: geometry.size.height - 10)
-                        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-
-                    // Animated timer ring at edge
-                    Circle()
-                        .trim(from: 0, to: viewModel.timeRemaining / viewModel.maxTimeForCurrentCommand)
-                        .stroke(
-                            viewModel.timeRemaining < 0.5 ? Color.red : Color.blue,
-                            style: StrokeStyle(lineWidth: 6, lineCap: .round)
-                        )
-                        .frame(width: geometry.size.width - 10, height: geometry.size.height - 10)
-                        .rotationEffect(.degrees(-90))
-                        .animation(.linear(duration: 0.05), value: viewModel.timeRemaining)
-                        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-                }
-            }
-            .ignoresSafeArea()
+            PerimeterProgressRing(
+                progress: perimeterProgress,
+                ringColor: timerRingColor
+            )
 
             // Content in center
             VStack(spacing: 12) {
@@ -76,7 +57,16 @@ struct GamePlayView: View {
         }
     }
 
-    // MARK: - Helper Views
+    // MARK: - Progress & Helper Views
+
+    private var perimeterProgress: Double {
+        guard viewModel.maxTimeForCurrentCommand > 0 else { return 0 }
+        return viewModel.timeRemaining / viewModel.maxTimeForCurrentCommand
+    }
+
+    private var timerRingColor: Color {
+        viewModel.timeRemaining < 0.5 ? .red : .blue
+    }
 
     private func gestureButton(for gesture: GestureType) -> some View {
         Button(action: {

--- a/WristBop/WristBop Watch App/PerimeterProgressRing.swift
+++ b/WristBop/WristBop Watch App/PerimeterProgressRing.swift
@@ -1,0 +1,53 @@
+//
+//  PerimeterProgressRing.swift
+//  WristBop Watch App
+//
+//  Created by Stewart Chan on 2025-12-07.
+//
+
+import SwiftUI
+
+struct PerimeterProgressRing: View {
+    var progress: Double
+    var ringColor: Color
+    var trackColor: Color = Color.gray.opacity(0.2)
+    var animationDuration: Double = 0.05
+    var ringWidthScale: CGFloat = 0.05
+    var cornerRadiusScale: CGFloat = 0.24
+    var showTrack: Bool = true
+
+    var body: some View {
+        GeometryReader { geometry in
+            let minSide = min(geometry.size.width, geometry.size.height)
+            let ringWidth = minSide * ringWidthScale
+            let cornerRadius = minSide * cornerRadiusScale
+            let clampedProgress = CGFloat(max(0, min(progress, 1)))
+
+            ZStack {
+                if showTrack {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .trim(from: 0, to: 1)
+                        .stroke(trackColor, style: StrokeStyle(lineWidth: ringWidth))
+                }
+
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .trim(from: 0, to: clampedProgress)
+                    .stroke(
+                        ringColor,
+                        style: StrokeStyle(lineWidth: ringWidth, lineCap: .round)
+                    )
+                    .animation(.linear(duration: animationDuration), value: clampedProgress)
+            }
+            .rotationEffect(.degrees(-90))
+            .padding(ringWidth / 2)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    PerimeterProgressRing(
+        progress: 0.65,
+        ringColor: .blue
+    )
+}


### PR DESCRIPTION
## Summary
- add reusable rounded-rectangle perimeter progress ring sized via geometry with track
- replace countdown and gameplay circular edge timers with the perimeter ring, preserving urgency color logic and animation
- clamp/guard progress inputs and keep padding/rotation so the ring hugs the watch face

## Testing
- swift test

Closes #17