### PR TITLE
Issue #31: fix: allow consecutive identical commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The project follows standard Swift Package conventions with clean separation bet
    - `GameConstants.swift`: Centralized tuning constants for difficulty curve
 
 2. **Supporting Systems**
-   - `CommandRandomizer.swift`: Protocol + `SystemCommandRandomizer` for generating non-repeating random commands
+   - `CommandRandomizer.swift`: Protocol + `SystemCommandRandomizer` for generating random commands (repeats allowed)
    - `HighScoreStore.swift`: Protocol + `UserDefaultsHighScoreStore` for persistence
 
 **Tests Location**: `Tests/WristBopCoreTests/`
@@ -147,7 +147,7 @@ This project follows a **TDD-first approach**:
 ## Important Architectural Constraints
 
 1. **Timeout-only failure**: Wrong gestures are silently ignored; only timing out ends the game
-2. **Non-repeating commands**: `CommandRandomizer` must exclude the previous command
+2. **Command randomness**: `CommandRandomizer` may consider the previous command but should choose uniformly across all gestures and allow repeats
 3. **Speed-up feedback**: `didTriggerSpeedUpCue` flag signals when haptic/sound cue should play (only when time actually decreases, not when at minimum)
 4. **Protocol injection**: Never hardcode concrete types in `GameEngine`; use protocol parameters for testability
 5. **Debug overlay**: Must be opt-in via compile-time flag, never shipped in release builds

--- a/Sources/WristBopCore/CommandRandomizer.swift
+++ b/Sources/WristBopCore/CommandRandomizer.swift
@@ -2,26 +2,17 @@ import Foundation
 
 /// Protocol for generating random gesture commands
 public protocol CommandRandomizer: Sendable {
-    /// Generates a random gesture command, excluding the previous command
-    /// - Parameter excluding: The previous command to exclude (optional)
-    /// - Returns: A random GestureType different from the excluded one
-    func nextCommand(excluding: GestureType?) -> GestureType
+    /// Generates a random gesture command.
+    /// - Parameter previous: The previously issued command (if any), provided for context.
+    func nextCommand(previous: GestureType?) -> GestureType
 }
 
 /// System implementation using SystemRandomNumberGenerator
 public struct SystemCommandRandomizer: CommandRandomizer {
     public init() {}
 
-    public func nextCommand(excluding: GestureType?) -> GestureType {
-        let allGestures = GestureType.allCases
-
-        guard let excluding = excluding else {
-            // No exclusion, return any random gesture
-            return allGestures.randomElement()!
-        }
-
-        // Filter out the excluded gesture
-        let available = allGestures.filter { $0 != excluding }
-        return available.randomElement()!
+    public func nextCommand(previous _: GestureType?) -> GestureType {
+        // Choose uniformly from all gestures; repeats are allowed.
+        return GestureType.allCases.randomElement()!
     }
 }

--- a/Sources/WristBopCore/GameEngine.swift
+++ b/Sources/WristBopCore/GameEngine.swift
@@ -115,6 +115,6 @@ public final class GameEngine: GameEngineProtocol, @unchecked Sendable {
     }
 
     public func nextCommand() -> GestureType {
-        return commandRandomizer.nextCommand(excluding: _state.currentCommand)
+        return commandRandomizer.nextCommand(previous: _state.currentCommand)
     }
 }

--- a/Tests/WristBopCoreTests/GameEngineTests.swift
+++ b/Tests/WristBopCoreTests/GameEngineTests.swift
@@ -218,22 +218,20 @@ struct GameEngineTests {
         #expect(store.loadHighScore() == 10)
     }
 
-    @Test("Next command excludes previous command")
-    func testNextCommandExcludesPrevious() {
-        let randomizer = SystemCommandRandomizer()
+    @Test("Next command can repeat previous command")
+    func testNextCommandCanRepeatPrevious() {
+        let randomizer = FixedCommandRandomizer(command: .shake)
         let store = InMemoryHighScoreStore()
         let engine = GameEngine(commandRandomizer: randomizer, highScoreStore: store)
 
         engine.startGame()
+        let firstCommand = engine.state.currentCommand!
+        #expect(firstCommand == .shake)
 
-        // Generate multiple commands and ensure they don't repeat
-        var previousCommand = engine.state.currentCommand!
+        // Repeating the same gesture should still advance the game and set the same command again
+        engine.handleGestureMatch(firstCommand)
+        let secondCommand = engine.state.currentCommand!
 
-        for _ in 0..<10 {
-            engine.handleGestureMatch(previousCommand)
-            let newCommand = engine.state.currentCommand!
-            #expect(newCommand != previousCommand)
-            previousCommand = newCommand
-        }
+        #expect(secondCommand == firstCommand)
     }
 }

--- a/Tests/WristBopCoreTests/TestDoubles.swift
+++ b/Tests/WristBopCoreTests/TestDoubles.swift
@@ -23,13 +23,26 @@ final class SequenceCommandRandomizer: CommandRandomizer, @unchecked Sendable {
         self.sequence = sequence
     }
 
-    func nextCommand(excluding: GestureType?) -> GestureType {
+    func nextCommand(previous _: GestureType?) -> GestureType {
         guard !sequence.isEmpty else {
             return .shake
         }
 
         let command = sequence[currentIndex % sequence.count]
         currentIndex += 1
+        return command
+    }
+}
+
+/// Command randomizer that always returns the same command (useful for repeat checks)
+final class FixedCommandRandomizer: CommandRandomizer, @unchecked Sendable {
+    private let command: GestureType
+
+    init(command: GestureType) {
+        self.command = command
+    }
+
+    func nextCommand(previous _: GestureType?) -> GestureType {
         return command
     }
 }

--- a/WristBop/WristBop Watch AppTests/GameViewModelTests.swift
+++ b/WristBop/WristBop Watch AppTests/GameViewModelTests.swift
@@ -419,7 +419,7 @@ private final class SequenceCommandRandomizer: CommandRandomizer, @unchecked Sen
         self.sequence = sequence
     }
 
-    func nextCommand(excluding: GestureType?) -> GestureType {
+    func nextCommand(previous _: GestureType?) -> GestureType {
         guard !sequence.isEmpty else { return .shake }
         let command = sequence[currentIndex % sequence.count]
         currentIndex += 1


### PR DESCRIPTION
## Issue
Closes #31

## Summary
- allow command randomizer to pick any gesture, including back-to-back repeats
- propagate new context-aware signature through engine and test doubles
- add deterministic test coverage proving consecutive identical commands are allowed

## Plan
- update randomizer API to allow repeats and keep selection uniform
- adjust engine usages and test doubles for the new signature
- add repeat-coverage test and run swift test

## Checklist
- [x] Allow consecutive identical commands
- [x] Update/add tests
- [x] swift test
- [ ] Manual verification in watchOS app